### PR TITLE
Add dbt formula for running dbt via uv tool

### DIFF
--- a/Formula/dbt.rb
+++ b/Formula/dbt.rb
@@ -1,0 +1,73 @@
+# typed: false
+# frozen_string_literal: true
+
+class Dbt < Formula
+  desc "Run dbt (data build tool) via uv with version pinning"
+  homepage "https://www.getdbt.com/"
+  version "1.10.8"
+  license "Apache-2.0"
+
+  # This is a wrapper formula, no actual download needed
+  url "data:text/plain,dbt"
+  sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+  depends_on "uv"
+
+  # Version pins
+  DBT_CORE_VERSION = "1.10.8".freeze
+  DBT_BIGQUERY_VERSION = "1.10.2".freeze
+  PYTHON_VERSION = "3.11.8".freeze
+
+  def install
+    # Create dbt wrapper script that uses uv tool install for faster startup
+    (bin/"dbt").write <<~EOS
+      #!/bin/bash
+
+      DBT_CORE_VERSION="#{DBT_CORE_VERSION}"
+      DBT_BIGQUERY_VERSION="#{DBT_BIGQUERY_VERSION}"
+      PYTHON_VERSION="#{PYTHON_VERSION}"
+
+      # Check if dbt is installed with the correct version
+      INSTALLED_VERSION=$(uv tool list 2>/dev/null | grep "dbt-core" | grep -o "v[0-9.]*" | sed 's/v//' || echo "")
+
+      if [ "$INSTALLED_VERSION" != "$DBT_CORE_VERSION" ]; then
+        echo "Installing dbt-core $DBT_CORE_VERSION with dbt-bigquery $DBT_BIGQUERY_VERSION..." >&2
+        uv tool install \\
+          --python "$PYTHON_VERSION" \\
+          --force \\
+          dbt-core=="$DBT_CORE_VERSION" \\
+          --with dbt-bigquery=="$DBT_BIGQUERY_VERSION"
+      fi
+
+      # Run the installed dbt (uv automatically adds tools to PATH)
+      exec "$(uv tool dir)/dbt-core/bin/dbt" "$@"
+    EOS
+
+    chmod 0755, bin/"dbt"
+  end
+
+  test do
+    # Test that the wrapper script exists and is executable
+    assert_predicate bin/"dbt", :exist?
+    assert_predicate bin/"dbt", :executable?
+  end
+
+  def caveats
+    <<~EOS
+      This formula provides dbt via uv with pinned versions:
+        - dbt-core: #{DBT_CORE_VERSION}
+        - dbt-bigquery: #{DBT_BIGQUERY_VERSION}
+        - Python: #{PYTHON_VERSION}
+
+      Usage:
+        dbt --version
+        dbt run
+        dbt test
+
+      The first run will download and cache the packages.
+      Subsequent runs will be faster.
+
+      To update versions, edit the formula's version constants.
+    EOS
+  end
+end


### PR DESCRIPTION
## Summary
- Adds new Homebrew formula for dbt (data build tool)
- Uses `uv tool install` for fast startup after initial installation
- Pins versions: dbt-core 1.10.8, dbt-bigquery 1.10.2, Python 3.11.8
- Provides `dbt` command that automatically manages installation via uv

## Features
- **Fast execution**: Uses persistent uv tool installation for near-instant startup
- **Version pinning**: Ensures consistent environments across installations
- **Auto-management**: Checks and installs/updates dbt on first run or version change
- **User feedback**: Shows "Installing..." message on first run to avoid confusion

## Usage
```bash
brew install loveholidays/tap/dbt
dbt --version
dbt run
```

## Test plan
- [x] Created and tested wrapper script locally
- [x] Verified Ruby syntax
- [x] Tested with existing uv-installed dbt-core
- [ ] Install via Homebrew tap and verify functionality
- [ ] Test version upgrade scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)